### PR TITLE
Fixed CancellationTokenSource-timeout not aborting while-loop

### DIFF
--- a/src/Svea.WebPay.SDK/SveaHttpClient.cs
+++ b/src/Svea.WebPay.SDK/SveaHttpClient.cs
@@ -153,7 +153,7 @@ namespace Svea.WebPay.SDK
                         {
                             if (taskResponse is object)
                             {
-                                await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(configureAwait);
+                                await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken.Token).ConfigureAwait(configureAwait);
                             }
 
                             taskResponse = await HttpGet<PaymentAdminApi.Models.Task>(response.ResourceUri, configureAwait).ConfigureAwait(configureAwait);


### PR DESCRIPTION
Fixed an issue where `PollingTimeout.Timeout` will not be respected, due to `IsCancellationRequested `not being checked and the `CancellationToken `not being passed to the `Task.Delay`-call.

This change will make sure that if the timeout has been triggered, then a `TaskCanceledException` will be thrown.
This will prevent the loop from continuing.