### PR TITLE
Update test data and adjust order attributes in PaymentAdminAPI

### DIFF
--- a/src/Svea.WebPay.SDK.Tests/Helpers/DataSample.cs
+++ b/src/Svea.WebPay.SDK.Tests/Helpers/DataSample.cs
@@ -4,70 +4,91 @@
     {
         public static string AdminGetOrder = @"
         {
-            ""Id"":2291662,
-            ""Currency"":""SEK"",
-            ""MerchantOrderId"":""637254821997417753"",
-            ""OrderStatus"":""Open"",
-            ""SystemStatus"":""Active"",
-            ""SystemStatusMessage"":null,
-            ""PaymentCreditStatus"":null,
-            ""EmailAddress"":""tess.persson@mail.com"",
-            ""PhoneNumber"":""08 111 111 11"",
-            ""CustomerReference"":"""",
-            ""PeppolId"":null,
-            ""PaymentType"":""Invoice"",
-            ""CreationDate"":""2020-06-23T20:21:17"",
-            ""NationalId"":""194605092222"",
-            ""IsCompany"":false,
-            ""CancelledAmount"":0,
-            ""OrderAmount"":536800,
-            ""BillingAddress"":
-            {
-                ""FullName"":""Persson Tess T"",
-                ""StreetAddress"":""Testgatan 1"",
-                ""CoAddress"":""c/o Eriksson, Erik"",
-                ""PostalCode"":""99999"",
-                ""City"":""Stan"",
-                ""CountryCode"":""SE""
-            },
-            ""ShippingAddress"":
-            {
-                ""FullName"":""Persson Tess T"",
-                ""StreetAddress"":""Testgatan 1"",
-                ""CoAddress"":""c/o Eriksson, Erik"",
-                ""PostalCode"":""99999"",
-                ""City"":""Stan"",
-                ""CountryCode"":""SE""
-            },
-            ""Deliveries"":[],
-            ""OrderRows"":[
-                {
-                    ""OrderRowId"":1,
-                    ""ArticleNumber"":""Ref1"",
-                    ""Name"":""Levis 511 Slim Fit"",
-                    ""Quantity"":200,
-                    ""UnitPrice"":89900,
-                    ""DiscountAmount"":0,
-                    ""VatPercent"":0,
-                    ""Unit"":""SEK"",
-                    ""IsCancelled"":false,
-                    ""Actions"":[""CanDeliverRow"",""CanCancelRow"",""CanUpdateRow""]},
-                {
-                    ""OrderRowId"":2,
-                    ""ArticleNumber"":""Ref2"",
-                    ""Name"":""Levis 501 Jeans"",
-                    ""Quantity"":300,
-                    ""UnitPrice"":119000,
-                    ""DiscountAmount"":0,
-                    ""VatPercent"":0,
-                    ""Unit"":""SEK"",
-                    ""IsCancelled"":false,
-                    ""Actions"":[""CanDeliverRow"",""CanCancelRow"",""CanUpdateRow""]
-                }
-            ],
-            ""Actions"":[""CanDeliverOrder"",""CanDeliverPartially"",""CanCancelOrder"",""CanCancelOrderRow"",""CanAddOrderRow"",""CanUpdateOrderRow""],
-            ""SveaWillBuy"":true
-        }";
+    ""Id"": 9123721,
+    ""Currency"": ""SEK"",
+    ""MerchantOrderId"": ""638484321479935320"",
+    ""OrderStatus"": ""Expired"",
+    ""SystemStatus"": ""Active"",
+    ""SystemStatusMessage"": null,
+    ""PaymentCreditStatus"": null,
+    ""EmailAddress"": ""fred.lunden@authority.se"",
+    ""BillingEmailAddress"": null,
+    ""PhoneNumber"": ""0701234567"",
+    ""CustomerReference"": """",
+    ""PeppolId"": null,
+    ""PaymentType"": ""Invoice"",
+    ""CreationDate"": ""2024-04-11T09:35:48"",
+    ""NationalId"": ""194605092222"",
+    ""IsCompany"": false,
+    ""CancelledAmount"": 0,
+    ""OrderAmount"": 388700,
+    ""BillingAddress"": {
+        ""FullName"": ""Persson, Tess T"",
+        ""StreetAddress"": ""Testgatan 1"",
+        ""CoAddress"": ""c/o Eriksson, Erik"",
+        ""PostalCode"": ""99999"",
+        ""City"": ""Stan"",
+        ""CountryCode"": ""SE"",
+        ""Source"": 1
+    },
+    ""ShippingAddress"": {
+        ""FullName"": ""asd asd"",
+        ""StreetAddress"": ""asd"",
+        ""CoAddress"": null,
+        ""PostalCode"": ""12345"",
+        ""City"": ""asd"",
+        ""CountryCode"": ""SE"",
+        ""Source"": 5
+    },
+    ""Deliveries"": [],
+    ""OrderRows"": [
+        {
+            ""OrderRowId"": 1,
+            ""ArticleNumber"": ""Ref1"",
+            ""Name"": ""Levis 511 Slim Fit"",
+            ""Quantity"": 300,
+            ""UnitPrice"": 89900,
+            ""DiscountPercent"": 0,
+            ""DiscountAmount"": 0,
+            ""VatPercent"": 0,
+            ""Unit"": null,
+            ""IsCancelled"": false,
+            ""Actions"": [
+                ""CanDeliverRow"",
+                ""CanCancelRow"",
+                ""CanUpdateRow""
+            ]
+        },
+        {
+            ""OrderRowId"": 2,
+            ""ArticleNumber"": ""Ref2"",
+            ""Name"": ""Levis 501 Jeans"",
+            ""Quantity"": 100,
+            ""UnitPrice"": 119000,
+            ""DiscountPercent"": 0,
+            ""DiscountAmount"": 0,
+            ""VatPercent"": 0,
+            ""Unit"": null,
+            ""IsCancelled"": false,
+            ""Actions"": [
+                ""CanDeliverRow"",
+                ""CanCancelRow"",
+                ""CanUpdateRow""
+            ]
+        }
+    ],
+    ""Actions"": [
+        ""CanDeliverOrder"",
+        ""CanDeliverPartially"",
+        ""CanCancelOrder"",
+        ""CanCancelOrderRow"",
+        ""CanAddOrderRow"",
+        ""CanUpdateOrderRow""
+    ],
+    ""SveaWillBuy"": true,
+    ""ExpirationDate"": ""2024-06-09T22:00:00"",
+    ""BillingReferences"": []
+}";
 
         public static string AdminDeliveredOrder = @"
         {

--- a/src/Svea.WebPay.SDK.Tests/Helpers/DataSample.cs
+++ b/src/Svea.WebPay.SDK.Tests/Helpers/DataSample.cs
@@ -4,91 +4,72 @@
     {
         public static string AdminGetOrder = @"
         {
-    ""Id"": 9123721,
-    ""Currency"": ""SEK"",
-    ""MerchantOrderId"": ""638484321479935320"",
-    ""OrderStatus"": ""Expired"",
-    ""SystemStatus"": ""Active"",
-    ""SystemStatusMessage"": null,
-    ""PaymentCreditStatus"": null,
-    ""EmailAddress"": ""fred.lunden@authority.se"",
-    ""BillingEmailAddress"": null,
-    ""PhoneNumber"": ""0701234567"",
-    ""CustomerReference"": """",
-    ""PeppolId"": null,
-    ""PaymentType"": ""Invoice"",
-    ""CreationDate"": ""2024-04-11T09:35:48"",
-    ""NationalId"": ""194605092222"",
-    ""IsCompany"": false,
-    ""CancelledAmount"": 0,
-    ""OrderAmount"": 388700,
-    ""BillingAddress"": {
-        ""FullName"": ""Persson, Tess T"",
-        ""StreetAddress"": ""Testgatan 1"",
-        ""CoAddress"": ""c/o Eriksson, Erik"",
-        ""PostalCode"": ""99999"",
-        ""City"": ""Stan"",
-        ""CountryCode"": ""SE"",
-        ""Source"": 1
-    },
-    ""ShippingAddress"": {
-        ""FullName"": ""asd asd"",
-        ""StreetAddress"": ""asd"",
-        ""CoAddress"": null,
-        ""PostalCode"": ""12345"",
-        ""City"": ""asd"",
-        ""CountryCode"": ""SE"",
-        ""Source"": 5
-    },
-    ""Deliveries"": [],
-    ""OrderRows"": [
-        {
-            ""OrderRowId"": 1,
-            ""ArticleNumber"": ""Ref1"",
-            ""Name"": ""Levis 511 Slim Fit"",
-            ""Quantity"": 300,
-            ""UnitPrice"": 89900,
-            ""DiscountPercent"": 0,
-            ""DiscountAmount"": 0,
-            ""VatPercent"": 0,
-            ""Unit"": null,
-            ""IsCancelled"": false,
-            ""Actions"": [
-                ""CanDeliverRow"",
-                ""CanCancelRow"",
-                ""CanUpdateRow""
-            ]
-        },
-        {
-            ""OrderRowId"": 2,
-            ""ArticleNumber"": ""Ref2"",
-            ""Name"": ""Levis 501 Jeans"",
-            ""Quantity"": 100,
-            ""UnitPrice"": 119000,
-            ""DiscountPercent"": 0,
-            ""DiscountAmount"": 0,
-            ""VatPercent"": 0,
-            ""Unit"": null,
-            ""IsCancelled"": false,
-            ""Actions"": [
-                ""CanDeliverRow"",
-                ""CanCancelRow"",
-                ""CanUpdateRow""
-            ]
-        }
-    ],
-    ""Actions"": [
-        ""CanDeliverOrder"",
-        ""CanDeliverPartially"",
-        ""CanCancelOrder"",
-        ""CanCancelOrderRow"",
-        ""CanAddOrderRow"",
-        ""CanUpdateOrderRow""
-    ],
-    ""SveaWillBuy"": true,
-    ""ExpirationDate"": ""2024-06-09T22:00:00"",
-    ""BillingReferences"": []
-}";
+            ""Id"":2291662,
+            ""Currency"":""SEK"",
+            ""MerchantOrderId"":""637254821997417753"",
+            ""OrderStatus"":""Expired"",
+            ""SystemStatus"":""Active"",
+            ""SystemStatusMessage"":null,
+            ""PaymentCreditStatus"":null,
+            ""EmailAddress"":""tess.persson@mail.com"",
+            ""PhoneNumber"":""08 111 111 11"",
+            ""CustomerReference"":"""",
+            ""PeppolId"":null,
+            ""PaymentType"":""Invoice"",
+            ""CreationDate"":""2020-06-23T20:21:17"",
+            ""NationalId"":""194605092222"",
+            ""IsCompany"":false,
+            ""CancelledAmount"":0,
+            ""OrderAmount"":536800,
+            ""BillingAddress"":
+            {
+                ""FullName"":""Persson Tess T"",
+                ""StreetAddress"":""Testgatan 1"",
+                ""CoAddress"":""c/o Eriksson, Erik"",
+                ""PostalCode"":""99999"",
+                ""City"":""Stan"",
+                ""CountryCode"":""SE""
+            },
+            ""ShippingAddress"":
+            {
+                ""FullName"":""Persson Tess T"",
+                ""StreetAddress"":""Testgatan 1"",
+                ""CoAddress"":""c/o Eriksson, Erik"",
+                ""PostalCode"":""99999"",
+                ""City"":""Stan"",
+                ""CountryCode"":""SE""
+            },
+            ""Deliveries"":[],
+            ""OrderRows"":[
+                {
+                    ""OrderRowId"":1,
+                    ""ArticleNumber"":""Ref1"",
+                    ""Name"":""Levis 511 Slim Fit"",
+                    ""Quantity"":200,
+                    ""UnitPrice"":89900,
+                    ""DiscountAmount"":0,
+                    ""VatPercent"":0,
+                    ""Unit"":""SEK"",
+                    ""IsCancelled"":false,
+                    ""Actions"":[""CanDeliverRow"",""CanCancelRow"",""CanUpdateRow""]},
+                {
+                    ""OrderRowId"":2,
+                    ""ArticleNumber"":""Ref2"",
+                    ""Name"":""Levis 501 Jeans"",
+                    ""Quantity"":300,
+                    ""UnitPrice"":119000,
+                    ""DiscountAmount"":0,
+                    ""VatPercent"":0,
+                    ""Unit"":""SEK"",
+                    ""IsCancelled"":false,
+                    ""Actions"":[""CanDeliverRow"",""CanCancelRow"",""CanUpdateRow""]
+                }
+            ],
+            ""Actions"":[""CanDeliverOrder"",""CanDeliverPartially"",""CanCancelOrder"",""CanCancelOrderRow"",""CanAddOrderRow"",""CanUpdateOrderRow""],
+            ""SveaWillBuy"":true,
+            ""ExpirationDate"": ""2024-06-09T22:00:00"",
+            ""BillingReferences"": []
+        }";
 
         public static string AdminDeliveredOrder = @"
         {

--- a/src/Svea.WebPay.SDK.Tests/PaymentAdminTests.cs
+++ b/src/Svea.WebPay.SDK.Tests/PaymentAdminTests.cs
@@ -419,7 +419,7 @@ namespace Svea.WebPay.SDK.Tests
             Assert.Equal(2291662, order.Id);
             Assert.Equal("SEK", order.Currency);
             Assert.Equal("637254821997417753", order.MerchantOrderId);
-            Assert.Equal(OrderStatus.Open, order.OrderStatus);
+            Assert.Equal(OrderStatus.Expired, order.OrderStatus);
             Assert.Equal("tess.persson@mail.com", order.EmailAddress.ToString());
             Assert.Equal("08 111 111 11", order.PhoneNumber);
             Assert.Equal("", order.CustomerReference);

--- a/src/Svea.WebPay.SDK.Tests/PaymentAdminTests.cs
+++ b/src/Svea.WebPay.SDK.Tests/PaymentAdminTests.cs
@@ -1,9 +1,13 @@
 ﻿using Xunit;
+
 using Moq;
+
 using Svea.WebPay.SDK.PaymentAdminApi;
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using Svea.WebPay.SDK.Tests.Helpers;
 using Svea.WebPay.SDK.Json;
 using Svea.WebPay.SDK.PaymentAdminApi.Response;
@@ -25,10 +29,12 @@ namespace Svea.WebPay.SDK.Tests
             var sveaClient = SveaClient(CreateHandlerMock(DataSample.AdminGetOrder));
 
             // Act
-            var actualOrder = await sveaClient.PaymentAdmin.GetOrder(2291662).ConfigureAwait(false);
+            var actualOrder = await sveaClient.PaymentAdmin.GetOrder(9788143).ConfigureAwait(false);
 
             // Assert
             Assert.True(DataComparison.OrdersAreEqual(expectedOrder, actualOrder));
+            Assert.Equal(expectedOrder.ExpirationDate, new DateTime(2024, 6, 9, 22, 0, 0));
+            Assert.Equal(expectedOrder.OrderStatus, OrderStatus.Expired);
         }
 
         [Fact]
@@ -82,7 +88,8 @@ namespace Svea.WebPay.SDK.Tests
             var orderResponseObject = JsonSerializer.Deserialize<OrderResponseObject>(DataSample.AdminDeliveredOrder, JsonSerialization.Settings);
             var expectedTask = JsonSerializer.Deserialize<Task>(DataSample.TaskResponse, JsonSerialization.Settings);
             var expectedOrder = new Order(orderResponseObject, null);
-            var sveaClient = SveaClient(CreateHandlerMockWithAction(DataSample.AdminGetOrder, "", expectedTask.ResourceUri.OriginalString, DataSample.TaskResponse, DataSample.AdminDeliveredOrder));
+            var sveaClient = SveaClient(CreateHandlerMockWithAction(DataSample.AdminGetOrder, "", expectedTask.ResourceUri.OriginalString, DataSample.TaskResponse,
+                DataSample.AdminDeliveredOrder));
 
             // Act
             var order = await sveaClient.PaymentAdmin.GetOrder(2291662).ConfigureAwait(false);
@@ -100,7 +107,8 @@ namespace Svea.WebPay.SDK.Tests
             var orderResponseObject = JsonSerializer.Deserialize<OrderResponseObject>(DataSample.AdminPartiallyDeliveredOrder, JsonSerialization.Settings);
             var expectedTask = JsonSerializer.Deserialize<Task>(DataSample.TaskResponse, JsonSerialization.Settings);
             var expectedOrder = new Order(orderResponseObject, null);
-            var sveaClient = SveaClient(CreateHandlerMockWithAction(DataSample.AdminGetOrder, "", expectedTask.ResourceUri.OriginalString, DataSample.TaskResponse, DataSample.AdminPartiallyDeliveredOrder));
+            var sveaClient = SveaClient(CreateHandlerMockWithAction(DataSample.AdminGetOrder, "", expectedTask.ResourceUri.OriginalString, DataSample.TaskResponse,
+                DataSample.AdminPartiallyDeliveredOrder));
 
             // Act
             var order = await sveaClient.PaymentAdmin.GetOrder(2291662).ConfigureAwait(false);
@@ -121,7 +129,8 @@ namespace Svea.WebPay.SDK.Tests
             var expectedTask = JsonSerializer.Deserialize<Task>(DataSample.TaskResponse, JsonSerialization.Settings);
             var expectedResponse = new Order(orderResponseObject, null);
 
-            var sveaClient = SveaClient(CreateHandlerMockWithAction(DataSample.AdminGetOrder, "", expectedTask.ResourceUri.OriginalString, DataSample.TaskResponse, DataSample.AddOrderRowResponse));
+            var sveaClient = SveaClient(CreateHandlerMockWithAction(DataSample.AdminGetOrder, "", expectedTask.ResourceUri.OriginalString, DataSample.TaskResponse,
+                DataSample.AddOrderRowResponse));
 
             // Act
             var order = await sveaClient.PaymentAdmin.GetOrder(2291662).ConfigureAwait(false);
@@ -153,14 +162,16 @@ namespace Svea.WebPay.SDK.Tests
             var expectedTask = JsonSerializer.Deserialize<Task>(DataSample.TaskResponse, JsonSerialization.Settings);
             var expectedResponse = new Order(orderResponseObject, null);
 
-            var sveaClient = SveaClient(CreateHandlerMockWithAction(DataSample.AdminGetOrder, "", expectedTask.ResourceUri.OriginalString, DataSample.TaskResponse, DataSample.AddOrderRowsResponse));
+            var sveaClient = SveaClient(CreateHandlerMockWithAction(DataSample.AdminGetOrder, "", expectedTask.ResourceUri.OriginalString, DataSample.TaskResponse,
+                DataSample.AddOrderRowsResponse));
 
             // Act
             var order = await sveaClient.PaymentAdmin.GetOrder(2291662).ConfigureAwait(false);
 
             var resourceResponse = await order.Actions.AddOrderRows(
                 new AddOrderRowsRequest(
-                    new List<NewOrderRow> {
+                    new List<NewOrderRow>
+                    {
                         new NewOrderRow(
                             name: "Slim Fit 512",
                             quantity: new MinorUnit(2),
@@ -199,12 +210,14 @@ namespace Svea.WebPay.SDK.Tests
             var creditResponseObject = JsonSerializer.Deserialize<CreditResponseObject>(DataSample.CreditResponse, JsonSerialization.Settings);
             var expectedTask = JsonSerializer.Deserialize<Task>(DataSample.TaskResponse, JsonSerialization.Settings);
             var expectedCreditResponse = new CreditResponse(creditResponseObject);
-            var sveaClient = SveaClient(CreateHandlerMockWithAction(DataSample.AdminDeliveredOrder, "", expectedTask.ResourceUri.OriginalString, DataSample.TaskResponse, DataSample.CreditResponse));
+            var sveaClient = SveaClient(CreateHandlerMockWithAction(DataSample.AdminDeliveredOrder, "", expectedTask.ResourceUri.OriginalString,
+                DataSample.TaskResponse, DataSample.CreditResponse));
 
             // Act
             var order = await sveaClient.PaymentAdmin.GetOrder(2291662).ConfigureAwait(false);
             var delivery = order.Deliveries.FirstOrDefault(dlv => dlv.Id == 5588817);
-            var orderRowIds = delivery.OrderRows.Where(row => row.AvailableActions.Contains(OrderRowActionType.CanCreditRow)).Select(row => (long)row.OrderRowId).ToList();
+            var orderRowIds = delivery.OrderRows.Where(row => row.AvailableActions.Contains(OrderRowActionType.CanCreditRow)).Select(row => (long)row.OrderRowId)
+                .ToList();
             var resourceResponse = await delivery.Actions.CreditOrderRows(new CreditOrderRowsRequest(orderRowIds), new PollingTimeout(15)).ConfigureAwait(false);
 
             // Assert
@@ -219,12 +232,14 @@ namespace Svea.WebPay.SDK.Tests
             var creditResponseObject = JsonSerializer.Deserialize<CreditResponseObject>(DataSample.CreditResponse, JsonSerialization.Settings);
             var expectedTask = JsonSerializer.Deserialize<Task>(DataSample.TaskResponse, JsonSerialization.Settings);
             var expectedCreditResponse = new CreditResponse(creditResponseObject);
-            var sveaClient = SveaClient(CreateHandlerMockWithAction(DataSample.AdminDeliveredOrder, "", expectedTask.ResourceUri.OriginalString, DataSample.TaskResponse, DataSample.CreditResponse));
+            var sveaClient = SveaClient(CreateHandlerMockWithAction(DataSample.AdminDeliveredOrder, "", expectedTask.ResourceUri.OriginalString,
+                DataSample.TaskResponse, DataSample.CreditResponse));
 
             // Act
             var order = await sveaClient.PaymentAdmin.GetOrder(2291662).ConfigureAwait(false);
             var delivery = order.Deliveries.FirstOrDefault(dlv => dlv.Id == 5588817);
-            var orderRowIds = delivery.OrderRows.Where(row => row.AvailableActions.Contains(OrderRowActionType.CanCreditRow)).Select(row => (long)row.OrderRowId).ToList();
+            var orderRowIds = delivery.OrderRows.Where(row => row.AvailableActions.Contains(OrderRowActionType.CanCreditRow)).Select(row => (long)row.OrderRowId)
+                .ToList();
             var resourceResponse = await delivery.Actions.CreditNewRow(new CreditNewOrderRowRequest(
                 new CreditOrderRow(
                     name: "Slim Fit 512",
@@ -275,7 +290,8 @@ namespace Svea.WebPay.SDK.Tests
             var order = await sveaClient.PaymentAdmin.GetOrder(2291662).ConfigureAwait(false);
             await order.Actions.UpdateOrderRows(
                 new UpdateOrderRowsRequest(
-                    new List<NewOrderRow> {
+                    new List<NewOrderRow>
+                    {
                         new NewOrderRow(
                             name: order.OrderRows.ElementAt(0).Name,
                             quantity: order.OrderRows.ElementAt(0).Quantity,
@@ -362,7 +378,8 @@ namespace Svea.WebPay.SDK.Tests
             var order = await sveaClient.PaymentAdmin.GetOrder(2291662).ConfigureAwait(false);
             await order.Actions.ReplaceOrderRows(
                 new ReplaceOrderRowsRequest(
-                    new List<NewOrderRow> {
+                    new List<NewOrderRow>
+                    {
                         new NewOrderRow(
                             name: "Slim Fit 512",
                             quantity: new MinorUnit(2),

--- a/src/Svea.WebPay.SDK/PaymentAdminApi/Models/Order.cs
+++ b/src/Svea.WebPay.SDK/PaymentAdminApi/Models/Order.cs
@@ -23,10 +23,13 @@
             OrderAmount = orderResponseObject.OrderAmount;
             OrderStatus = orderResponseObject.OrderStatus;
             PaymentType = orderResponseObject.PaymentType;
+            PeppolId = orderResponseObject.PeppolId;
             PhoneNumber = orderResponseObject.PhoneNumber;
             ShippingAddress = orderResponseObject.ShippingAddress;
             SveaWillBuy = orderResponseObject.SveaWillBuy;
             AvailableActions = orderResponseObject.Actions;
+            ExpirationDate = orderResponseObject.ExpirationDate;
+            BillingEmailAddress = orderResponseObject.BillingEmailAddress;
 
             Actions = new OrderActions(orderResponseObject, client);
             OrderRows = orderResponseObject.OrderRows?.Select(x => new OrderRow(orderResponseObject.Id, x, client)).ToList();
@@ -51,8 +54,11 @@
         public IList<OrderRow> OrderRows { get; }
         public OrderStatus OrderStatus { get; }
         public PaymentType PaymentType { get; }
+        public string PeppolId { get; set; }
         public string PhoneNumber { get; }
         public Address ShippingAddress { get; }
         public bool? SveaWillBuy { get; }
+        public DateTime ExpirationDate { get; set; }
+        public string BillingEmailAddress { get; set; }
     }
 }

--- a/src/Svea.WebPay.SDK/PaymentAdminApi/OrderStatus.cs
+++ b/src/Svea.WebPay.SDK/PaymentAdminApi/OrderStatus.cs
@@ -28,5 +28,10 @@
         /// The order does not have a set Payment Method
         /// </summary>
         Processing, 
+        
+        /// <summary>
+        /// The order has expired. This is applicable for Invoice, Account credit and Payment plan order types.
+        /// </summary>
+        Expired
     }
 }

--- a/src/Svea.WebPay.SDK/PaymentAdminApi/Response/OrderResponseObject.cs
+++ b/src/Svea.WebPay.SDK/PaymentAdminApi/Response/OrderResponseObject.cs
@@ -1,6 +1,5 @@
 ﻿namespace Svea.WebPay.SDK.PaymentAdminApi.Response
 {
-
     using System;
     using System.Collections.Generic;
     using System.Text.Json.Serialization;
@@ -13,7 +12,8 @@
         public OrderResponseObject(IList<string> actions, Address billingAddress, MinorUnit cancelledAmount, DateTime creationDate,
             string currency, string customerReference, IList<DeliveryResponseObject> deliveries, EmailAddress emailAddress, long id,
             bool isCompany, string merchantOrderId, string nationalId, MinorUnit orderAmount, IList<OrderRowResponseObject> orderRows,
-            OrderStatus orderStatus, PaymentType paymentType, string phoneNumber, Address shippingAddress, bool? sveaWillBuy)
+            OrderStatus orderStatus, PaymentType paymentType, string peppolId, string phoneNumber, Address shippingAddress, bool? sveaWillBuy, 
+            DateTime expirationDate, string billingEmailAddress)
         {
             Actions = actions;
             BillingAddress = billingAddress;
@@ -31,9 +31,12 @@
             OrderRows = orderRows;
             OrderStatus = orderStatus;
             PaymentType = paymentType;
+            PeppolId = peppolId;
             PhoneNumber = phoneNumber;
             ShippingAddress = shippingAddress;
             SveaWillBuy = sveaWillBuy;
+            ExpirationDate = expirationDate;
+            BillingEmailAddress = billingEmailAddress;
         }
 
         /// <summary>
@@ -136,18 +139,36 @@
         /// Minimum 6 characters long Peppol Identifier.
         /// </summary>
         [JsonInclude]
-        public string PhoneNumber { get; }
-
+        public string PeppolId { get; set; }
+        
         /// <summary>
         /// The customer’s phone number.
         /// </summary>
         [JsonInclude]
-        public Address ShippingAddress { get; }
+        public string PhoneNumber { get; }
 
         /// <summary>
         /// Shipping address of identified customer.
         /// </summary>
         [JsonInclude]
+        public Address ShippingAddress { get; }
+
+        /// <summary>
+        /// Only available on Invoice order. Is true if Svea buys the invoice.
+        /// </summary>
+        [JsonInclude]
         public bool? SveaWillBuy { get; }
+        
+        /// <summary>
+        /// Date and time when the order will be expired.
+        /// </summary>
+        [JsonInclude]
+        public DateTime ExpirationDate { get; set; }
+        
+        /// <summary>
+        /// Email address of identified customer.
+        /// </summary>
+        [JsonInclude]
+        public string BillingEmailAddress { get; set; }
     }
 }


### PR DESCRIPTION
The modifications include an update to the test data in SDK.Tests. Changes have also been made in the PaymentAdminAPI models and responses where new attributes such as 'ExpirationDate' and 'BillingEmailAddress' have been added to the 'Order' model. Additionally, a new 'Expired' status has been added to the order statuses. This provides additional relevant information about the order status and contact details.